### PR TITLE
return empty list if services is not a list

### DIFF
--- a/git_metrics.py
+++ b/git_metrics.py
@@ -199,7 +199,11 @@ class SaasGitMetrics(GitMetrics):
         if not isinstance(services_file, dict):
             return []
 
-        return services_file.get('services', [])
+        services = services_file.get('services', [])
+        if not isinstance(services, list):
+            return []
+
+        return services
 
     def fetch_repo_metrics(self, repo):
         repo_metrics = GitMetrics(repo, bare=True, cache=self.cache)


### PR DESCRIPTION
push-saas-metrics has been failing due to services not being a list:
https://gitlab.cee.redhat.com/service/saas-cvexporter/blob/c2e4c0d3a32f8e655a09d9c08a1e0c037ec825c5/cvexporter-services/cvexporter.yaml#L1

this PR adds a error handle to skip such cases.